### PR TITLE
fix(suno): initialise retry_count before the generate request (UnboundLocalError swallows the 401 retry)

### DIFF
--- a/run/ai_generated_art/service/suno_api.py
+++ b/run/ai_generated_art/service/suno_api.py
@@ -140,6 +140,7 @@ async def generate_songs(cookie: str, prompt: str = "", tags: str = "", negative
     PAYLOAD['make_instrumental'] = make_instrumental
     
     downloaded_files = []
+    retry_count = 0
     
     async with httpx.AsyncClient(proxies=proxies, timeout=60) as client:
         try:
@@ -175,7 +176,6 @@ async def generate_songs(cookie: str, prompt: str = "", tags: str = "", negative
             print(f"成功发起请求, 获得 Clip IDs: {clip_ids}")
             
             pending_ids = list(clip_ids)
-            retry_count = 0
             retry_count = 0
             while pending_ids:
                 print(f"\n等待 10 秒后开始轮询... 剩余待处理 IDs: {len(pending_ids)}")


### PR DESCRIPTION
## Problem

In `run/ai_generated_art/service/suno_api.py`, `generate_songs()` handles a 401 from the generate request like this:

```python
# lines 154-162
response = await client.post(generate_url, headers=HEADERS, json=PAYLOAD)
if response.status_code == 401:
    if retry_count >= max_retries:          # <-- read here
        raise Exception(f"Authorization expired after {max_retries} retries during generation. ...")
    retry_count += 1
    authorization = get_authorization_token(cookie)
    HEADERS['authorization'] = authorization
    print(f"Authorization updated for generation, retrying... (attempt {retry_count})")
    response = await client.post(generate_url, headers=HEADERS, json=PAYLOAD)
```

`retry_count` is never assigned before this point. Its only assignments are further down, just before the polling loop:

```python
# lines 177-179
pending_ids = list(clip_ids)
retry_count = 0
retry_count = 0
```

Because those assignments exist in the same function, `retry_count` is a local name, so the read at line 156 raises `UnboundLocalError`, not `NameError` — and it fires on the very first 401.

## Impact

The whole body sits inside:

```python
# lines 241-243
except Exception as e:
    print(f"发生未知错误: {e}")
    return downloaded_files
```

so the error is swallowed and `generate_songs()` returns `[]`. `run/ai_generated_art/suno.py:109` then falls into its failure branch. Net effect: when the Suno cookie has expired — precisely the situation this retry block exists to recover from — the token is never refreshed and the user is told generation failed.

## Verification

Ran the real module with a stubbed `httpx.AsyncClient` whose `post()` returns 401:

```
[UNPATCHED] returned []
[UNPATCHED]  发生未知错误: cannot access local variable 'retry_count' where it is not associated with a value

[PATCHED]   returned []
[PATCHED]    Authorization updated for generation, retrying... (attempt 1)
[PATCHED]    发生未知错误: should not get here      <- the stub's raise_for_status, i.e. the retry actually happened
```

## Fix

Initialise `retry_count = 0` next to `downloaded_files = []`, before the request. The reset before the polling loop is kept (the polling retries should get their own budget), but the duplicated line is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
